### PR TITLE
Fix enum conversion issue with postgresql

### DIFF
--- a/docker/db/schema.sql
+++ b/docker/db/schema.sql
@@ -1,17 +1,9 @@
-CREATE TYPE state_abbreviation AS ENUM (
-    'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
-    'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
-    'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
-    'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
-    'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'
-);
 -- Step 2: Create the city table
 CREATE TABLE city (
     city_id SERIAL PRIMARY KEY,
     city_name VARCHAR(100) NOT NULL,
-    state_abbreviation state_abbreviation NOT NULL
+    state_abbreviation VARCHAR(2) NOT NULL
 );
-
 -- Step 4: Create the zipcode table
 CREATE TABLE zipcode (
     zip_code_id SERIAL PRIMARY KEY,

--- a/src/main/java/example/addressrepo/jpa/City.java
+++ b/src/main/java/example/addressrepo/jpa/City.java
@@ -1,7 +1,14 @@
 package example.addressrepo.jpa;
 
 import example.addressrepo.model.StateAbbreviation;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -20,7 +27,7 @@ public class City {
     @Column(name = "city_name", nullable = false)
     private String cityName;
 
-    @Enumerated(EnumType.STRING) // Ensure this maps to the enum as a string in the DB
+    @Enumerated(EnumType.STRING)
     @Column(name = "state_abbreviation", nullable = false)
     private StateAbbreviation stateAbbreviation;
 }

--- a/src/main/java/example/addressrepo/repository/AddressRepository.java
+++ b/src/main/java/example/addressrepo/repository/AddressRepository.java
@@ -10,4 +10,5 @@ public interface AddressRepository extends CrudRepository<Address, UUID>, Paging
     boolean existsByStreet(String street);
     boolean existsByCityId(Integer cityId);
     boolean existsByZipCodeId(Integer zipCodeId);
+    boolean existsByStreetAndCityIdAndZipCodeId(String street, Integer cityId, Integer ZipCodeId);
 }

--- a/src/main/java/example/addressrepo/repository/CityRepository.java
+++ b/src/main/java/example/addressrepo/repository/CityRepository.java
@@ -1,15 +1,12 @@
 package example.addressrepo.repository;
 
 import example.addressrepo.jpa.City;
-import org.springframework.data.jpa.repository.Query;
+import example.addressrepo.model.StateAbbreviation;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 public interface CityRepository extends CrudRepository<City, Integer> {
-    //boolean existsByCityNameAndStateAbbreviation(String cityName, StateAbbreviation stateAbbreviation);
-    @Query(value = "SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END " +
-            "FROM city c WHERE c.city_name = :cityName AND c.state_abbreviation = CAST(:stateAbbreviation AS state_abbreviation)",
-            nativeQuery = true)
-    boolean existsByCityNameAndStateAbbreviation(@Param("cityName") String cityName, @Param("stateAbbreviation") String stateAbbreviation);
+    boolean existsByCityNameAndStateAbbreviation(@Param("cityName") String cityName, @Param("stateAbbreviation") StateAbbreviation stateAbbreviation);
+
     boolean existsById(@Param("cityId") Integer id);
 }

--- a/src/main/java/example/addressrepo/service/AddressService.java
+++ b/src/main/java/example/addressrepo/service/AddressService.java
@@ -40,10 +40,7 @@ public class AddressService {
     }
 
     public boolean addressAvailable(AddressDto addressDto) {
-        boolean availableStreet = addressRepository.existsByStreet(addressDto.getStreet());
-        boolean cityId = addressRepository.existsByCityId(addressDto.getCityId());
-        boolean zipCodeId = addressRepository.existsByZipCodeId(addressDto.getZipCodeId());
-        if (availableStreet && cityId && zipCodeId) {
+        if (addressRepository.existsByStreetAndCityIdAndZipCodeId(addressDto.getStreet(), addressDto.getCityId(), addressDto.getZipCodeId())) {
             throw new DuplicateException("The address already exists");
         }
         return true;

--- a/src/main/java/example/addressrepo/service/AddressService.java
+++ b/src/main/java/example/addressrepo/service/AddressService.java
@@ -28,7 +28,7 @@ public class AddressService {
     private final AddressMapper addressMapper;
 
     public boolean validZipCode(Integer zipCodeId) {
-        if (zipCodeRepository.findById(zipCodeId).isPresent()) {
+        if (zipCodeRepository.existsById(zipCodeId)){
             return true;
         } else throw new DoesNotExistsException("Zip Code: " + zipCodeId + " does not exist");
     }

--- a/src/main/java/example/addressrepo/service/CityService.java
+++ b/src/main/java/example/addressrepo/service/CityService.java
@@ -18,7 +18,7 @@ public class CityService {
         return toDto(city);
     }*/
     public CityDto createCity(CityDto cityDto) {
-        if (cityRepository.existsByCityNameAndStateAbbreviation(cityDto.getCityName(), cityDto.getStateAbbreviation().name())) {
+        if (cityRepository.existsByCityNameAndStateAbbreviation(cityDto.getCityName(), cityDto.getStateAbbreviation())) {
             throw new DuplicateException("City already exists: " + cityDto.getCityName() + " in the state " +
                     cityDto.getStateAbbreviation().getStateDescription());
         }


### PR DESCRIPTION
Postgresql uses some native types to be able to convert enum that were removed in Hybernate 6.5. Avoid type conversion by keeping the enum type at the entity level and storing it as string in the db column.